### PR TITLE
Remove unused and unsafe deps

### DIFF
--- a/clients/generic/requirements.txt
+++ b/clients/generic/requirements.txt
@@ -1,6 +1,4 @@
-cchardet==2.1.5
 click==7.0
-PyYAML==5.3
+PyYAML==5.4
 requests==2.23.0
 paho-mqtt==1.5.0
-RPi.GPIO


### PR DESCRIPTION
The reasons for this PR are:
- [x] cchardet==2.1.5,  was unused
- [x] PyYAML==5.3, had a security issue [CVE-2020-14343](https://github.com/advisories/GHSA-8q59-q68h-6hv4)
- [x] RPi.GPIO, was unused

The proposed `requirement.txt` should be the minimal set of dependencies used in the current state of the `generic` client